### PR TITLE
do not add extra include directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -355,8 +355,6 @@ class pil_build_ext(build_ext):
         library_dirs = []
         include_dirs = []
 
-        _add_directory(include_dirs, "src/libImaging")
-
         pkg_config = None
         if _cmd_exists(os.environ.get("PKG_CONFIG", "pkg-config")):
             pkg_config = _pkg_config
@@ -765,7 +763,7 @@ class pil_build_ext(build_ext):
             self._remove_extension("PIL._webp")
 
         tk_libs = ["psapi"] if sys.platform == "win32" else []
-        self._update_extension("PIL._imagingtk", tk_libs, include_dirs=["src/Tk"])
+        self._update_extension("PIL._imagingtk", tk_libs)
 
         build_ext.build_extensions(self)
 

--- a/src/_imagingft.c
+++ b/src/_imagingft.c
@@ -49,7 +49,7 @@
 #define FT_ERROR_START_LIST  {
 #define FT_ERROR_END_LIST    { 0, 0 } };
 
-#include <raqm.h>
+#include "libImaging/raqm.h"
 
 #define LAYOUT_FALLBACK 0
 #define LAYOUT_RAQM 1


### PR DESCRIPTION
@nulano:

I tried to remove the `libImaging` directory from the includes added in `setup.py` so future includes can't omit the prefix by accident, but this causes a failure building `_imagingft.c` on systems without libraqm. Fixing this requires changing
```
#include <raqm.h>
```
to
```
#include "libImaging/raqm.h"
```
so I'm not sure it is worth it. Thoughts?